### PR TITLE
Add package signed record schema

### DIFF
--- a/common-1.schema.json
+++ b/common-1.schema.json
@@ -124,6 +124,16 @@
         "py:ansible-1.9.3-0-py27_0"
       ]
     },
+    "license": {
+      "$comment": "TODO don't allow null",
+      "type": ["string", "null"],
+      "title": "The package's license.",
+      "description": "A free-form text field describing the packages license.",
+      "patchable": true,
+      "examples": [
+        "MIT"
+      ]
+    },
     "license_family": {
       "type": "string",
       "description": "The license under which the package is distributed. Must conform to the license families listed at https://github.com/conda/conda-build/blob/3.19.1/conda_build/license_family.py#L8-L24.",
@@ -174,12 +184,80 @@
         1539182577753
       ]
     },
+    "sha256": {
+      "type": "string",
+      "description": "The sha256 hash of the package file.",
+      "patchable": false,
+      "pattern": "^[0-9a-f]{64}$",
+      "examples": [
+        "2efb3826d65af3f3857a35f04a0ba5c6288b9b3e4e47c9e2118fbdcc190406b9"
+      ]
+    },
+    "size": {
+      "type": "integer",
+      "description": "The size of the package file in bytes.",
+      "patchable": false,
+      "minimum": 0,
+      "examples": [
+        15874157
+      ]
+    },
+    "md5": {
+      "type": "string",
+      "description": "The md5 hash of the package file.",
+      "pattern": "^[0-9a-f]{32}$",
+      "examples": [
+        "9ceda9e08e97868b6ff7c0961a40544f"
+      ]
+    },
+    "depends": {
+      "type": "array",
+      "description": "The package's dependencies. A list of MatchSpecs required when installing the package.",
+      "patchable": true,
+      "items": {
+        "type": "string",
+        "description": "Valid Conda MatchSpec.",
+        "examples": [
+          "geos >=3.6.2,<3.6.3.0a0",
+          "matplotlib >=1.0.0",
+          "numpy >=1.11.3,<2.0a0",
+          "pyproj >=1.9.3",
+          "pyshp >=1.2.0",
+          "python >=2.7,<2.8.0a0",
+          "six",
+          "vc 9.*"
+        ]
+      }
+    },
+    "constrains": {
+      "type": "array",
+      "description": "The package's constraints on other packages in the environment. If the package is to be installed into an environment, the other packages in the environment must conform to these constratins. A constraint can be thought of as a 'reverse dependency'.",
+      "patchable": true,
+      "items": {
+        "type": "string",
+        "description": "Valid Conda MatchSpec.",
+        "examples": [
+          "proj4 <6",
+          "proj <6"
+        ]
+      }
+    },
     "vuln_id": {
       "description": "A CVE or other vulnerability identifier.",
       "type": "string",
       "pattern": "^CVE-[0-9]{4}-[0-9]{4,8}$",
       "examples": [
         "CVE-2017-14501"
+      ]
+    },
+    "noarch": {
+      "deprecated": true,
+      "type": "string",
+      "description": "The noarch type of a package (if applicable).",
+      "patchable": true,
+      "enum": [
+        "generic",
+        "python"
       ]
     }
   }

--- a/package-signed-record-1.schema.json
+++ b/package-signed-record-1.schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://schemas.conda.io/package-signed-meta-1.schema.json",
+  "type": "object",
+  "title": "Conda Package Metadata Signed Record Schema",
+  "description": "The schema for each package file's block of metadata in repodata, used for signature.",
+  "required": [
+    "subdir",
+    "name",
+    "version",
+    "build_number",
+    "build",
+    "depends",
+    "constrains",
+    "sha256",
+    "timestamp",
+    "size",
+    "md5"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "signed_record_version": {
+      "type": "integer",
+      "description": "The API version or schema version of the signed record.",
+      "const": 1,
+      "patchable": true
+    },
+    "origin_channel_name": {"$ref": "common-1.schema.json#/definitions/origin_channel_name"},
+    "subdir": {"$ref": "common-1.schema.json#/definitions/subdir"},
+    "namespace": {"$ref": "common-1.schema.json#/definitions/namespace"},
+    "name": {"$ref": "common-1.schema.json#/definitions/name"},
+    "version": {"$ref": "common-1.schema.json#/definitions/package_version"},
+    "build_number": {"$ref": "common-1.schema.json#/definitions/build_number"},
+    "build": {"$ref": "common-1.schema.json#/definitions/build"},
+    "depends": {"$ref": "common-1.schema.json#/definitions/depends"},
+    "constrains": {"$ref": "common-1.schema.json#/definitions/constrains"},
+    "sha256": {"$ref": "common-1.schema.json#/definitions/sha256"},
+    "size": {"$ref": "common-1.schema.json#/definitions/size"},
+    "md5": {"$ref": "common-1.schema.json#/definitions/md5"},
+    "timestamp": {"$ref": "common-1.schema.json#/definitions/timestamp"},
+    "noarch": {"$ref": "common-1.schema.json#/definitions/noarch"}
+  }
+}

--- a/repodata-record-1.schema.json
+++ b/repodata-record-1.schema.json
@@ -39,32 +39,9 @@
         "basemap-1.2.0-py27hbee0394_0.conda"
       ]
     },
-    "sha256": {
-      "type": "string",
-      "description": "The sha256 hash of the package file.",
-      "patchable": false,
-      "pattern": "^[0-9a-f]{64}$",
-      "examples": [
-        "2efb3826d65af3f3857a35f04a0ba5c6288b9b3e4e47c9e2118fbdcc190406b9"
-      ]
-    },
-    "size": {
-      "type": "integer",
-      "description": "The size of the package file in bytes.",
-      "patchable": false,
-      "minimum": 0,
-      "examples": [
-        15874157
-      ]
-    },
-    "md5": {
-      "type": "string",
-      "description": "The md5 hash of the package file.",
-      "pattern": "^[0-9a-f]{32}$",
-      "examples": [
-        "9ceda9e08e97868b6ff7c0961a40544f"
-      ]
-    },
+    "sha256": {"$ref": "common-1.schema.json#/definitions/sha256"},
+    "size": {"$ref": "common-1.schema.json#/definitions/size"},
+    "md5": {"$ref": "common-1.schema.json#/definitions/md5"},
     "timestamp": {"$ref": "common-1.schema.json#/definitions/timestamp"},
     "patch_version": {
       "type": "integer",
@@ -72,38 +49,8 @@
       "description": "Metadata record patch version. Incremented for each change of the metadata record.",
       "patchable": true
     },
-    "depends": {
-      "type": "array",
-      "description": "The package's dependencies. A list of MatchSpecs required when installing the package.",
-      "patchable": true,
-      "items": {
-        "type": "string",
-        "description": "Valid Conda MatchSpec.",
-        "examples": [
-          "geos >=3.6.2,<3.6.3.0a0",
-          "matplotlib >=1.0.0",
-          "numpy >=1.11.3,<2.0a0",
-          "pyproj >=1.9.3",
-          "pyshp >=1.2.0",
-          "python >=2.7,<2.8.0a0",
-          "six",
-          "vc 9.*"
-        ]
-      }
-    },
-    "constrains": {
-      "type": "array",
-      "description": "The package's constraints on other packages in the environment. If the package is to be installed into an environment, the other packages in the environment must conform to these constratins. A constraint can be thought of as a 'reverse dependency'.",
-      "patchable": true,
-      "items": {
-        "type": "string",
-        "description": "Valid Conda MatchSpec.",
-        "examples": [
-          "proj4 <6",
-          "proj <6"
-        ]
-      }
-    },
+    "depends": {"$ref": "common-1.schema.json#/definitions/depends"},
+    "constrains": {"$ref": "common-1.schema.json#/definitions/constrains"},
     "features": {
       "deprecated": true,
       "type": "string",
@@ -127,16 +74,7 @@
         "python"
       ]
     },
-    "license": {
-      "$comment": "TODO don't allow null",
-      "type": ["string", "null"],
-      "title": "The package's license.",
-      "description": "A free-form text field describing the packages license.",
-      "patchable": true,
-      "examples": [
-        "MIT"
-      ]
-    },
+    "license": {"$ref": "common-1.schema.json#/definitions/license"},
     "license_family": {"$ref": "common-1.schema.json#/definitions/license_family"},
     "spdx_license": {"$ref": "common-1.schema.json#/definitions/spdx_license"},
     "vulns_active": {


### PR DESCRIPTION
Description
---

[WIP] add package signed record
move some definitions in common defs: `license`, `sha256`, `md5`, `size`, `depends`, `constrains`, `noarch`
reuse shared definitions in repodata record and package signed record schema

Should be the implementation of https://github.com/conda/conda-content-trust/issues/8

I'm still not comfortable with the `patchable` key, I'll open an issue for that.