### PR TITLE
add schemas for about, index and paths under info

### DIFF
--- a/info-about-1.schema.json
+++ b/info-about-1.schema.json
@@ -1,0 +1,146 @@
+{
+  "title": "Model",
+  "type": "object",
+  "properties": {
+    "channels": {
+      "title": "Channels",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "conda_build_version": {
+      "title": "Conda Build Version",
+      "type": "string"
+    },
+    "conda_private": {
+      "title": "Conda Private",
+      "type": "boolean"
+    },
+    "conda_version": {
+      "title": "Conda Version",
+      "type": "string"
+    },
+    "description": {
+      "title": "Description",
+      "type": "string"
+    },
+    "dev_url": {
+      "title": "Dev Url",
+      "type": "string"
+    },
+    "doc_url": {
+      "title": "Doc Url",
+      "type": "string"
+    },
+    "env_vars": {
+      "$ref": "#/definitions/EnvVars"
+    },
+    "extra": {
+      "$ref": "#/definitions/Extra"
+    },
+    "home": {
+      "title": "Home",
+      "type": "string"
+    },
+    "identifiers": {
+      "title": "Identifiers",
+      "type": "array",
+      "items": {}
+    },
+    "keywords": {
+      "title": "Keywords",
+      "type": "array",
+      "items": {}
+    },
+    "license": {
+      "title": "License",
+      "type": "string"
+    },
+    "license_family": {
+      "title": "License Family",
+      "type": "string"
+    },
+    "license_file": {
+      "title": "License File",
+      "type": "string"
+    },
+    "root_pkgs": {
+      "title": "Root Pkgs",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "summary": {
+      "title": "Summary",
+      "type": "string"
+    },
+    "tags": {
+      "title": "Tags",
+      "type": "array",
+      "items": {}
+    }
+  },
+  "required": [
+    "channels",
+    "conda_build_version",
+    "conda_private",
+    "conda_version",
+    "description",
+    "dev_url",
+    "doc_url",
+    "env_vars",
+    "extra",
+    "home",
+    "identifiers",
+    "keywords",
+    "license",
+    "license_family",
+    "license_file",
+    "root_pkgs",
+    "summary",
+    "tags"
+  ],
+  "definitions": {
+    "EnvVars": {
+      "title": "EnvVars",
+      "type": "object",
+      "properties": {
+        "CIO_TEST": {
+          "title": "Cio Test",
+          "type": "string"
+        }
+      },
+      "required": [
+        "CIO_TEST"
+      ]
+    },
+    "Extra": {
+      "title": "Extra",
+      "type": "object",
+      "properties": {
+        "copy_test_source_files": {
+          "title": "Copy Test Source Files",
+          "type": "boolean"
+        },
+        "final": {
+          "title": "Final",
+          "type": "boolean"
+        },
+        "recipe-maintainers": {
+          "title": "Recipe-Maintainers",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "copy_test_source_files",
+        "final",
+        "recipe-maintainers"
+      ]
+    }
+  }
+}

--- a/info-index-1.schema.json
+++ b/info-index-1.schema.json
@@ -1,0 +1,74 @@
+{
+  "title": "Model",
+  "type": "object",
+  "properties": {
+    "arch": {
+      "title": "Arch",
+      "type": "string"
+    },
+    "build": {
+      "title": "Build",
+      "type": "string"
+    },
+    "build_number": {
+      "title": "Build Number",
+      "type": "integer"
+    },
+    "constrains": {
+      "title": "Constrains",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "depends": {
+      "title": "Depends",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "license": {
+      "title": "License",
+      "type": "string"
+    },
+    "license_family": {
+      "title": "License Family",
+      "type": "string"
+    },
+    "name": {
+      "title": "Name",
+      "type": "string"
+    },
+    "platform": {
+      "title": "Platform",
+      "type": "string"
+    },
+    "subdir": {
+      "title": "Subdir",
+      "type": "string"
+    },
+    "timestamp": {
+      "title": "Timestamp",
+      "type": "integer"
+    },
+    "version": {
+      "title": "Version",
+      "type": "string"
+    }
+  },
+  "required": [
+    "arch",
+    "build",
+    "build_number",
+    "constrains",
+    "depends",
+    "license",
+    "license_family",
+    "name",
+    "platform",
+    "subdir",
+    "timestamp",
+    "version"
+  ]
+}

--- a/info-paths-1.schema.json
+++ b/info-paths-1.schema.json
@@ -1,0 +1,54 @@
+{
+  "title": "Model",
+  "type": "object",
+  "properties": {
+    "paths": {
+      "title": "Paths",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Path"
+      }
+    },
+    "paths_version": {
+      "title": "Paths Version",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "paths",
+    "paths_version"
+  ],
+  "definitions": {
+    "Path": {
+      "title": "Path",
+      "type": "object",
+      "properties": {
+        "path_type": {
+          "title": "Path Type",
+          "type": "string"
+        },
+        "sha256": {
+          "title": "Sha256",
+          "type": "string"
+        },
+        "size_in_bytes": {
+          "title": "Size In Bytes",
+          "type": "integer"
+        },
+        "file_mode": {
+          "title": "File Mode",
+          "type": "string"
+        },
+        "prefix_placeholder": {
+          "title": "Prefix Placeholder",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path_type",
+        "sha256",
+        "size_in_bytes"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This is the first iteration at getting the schemas for `about.json`, `index.json` and `paths.json` files under the `info` directory of packages.

CC: @wolfv