### PR TITLE
Integrate with the JSON Schema CLI for formatting and linting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,12 @@
+name: Test
+
+on: [ push, pull_request ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: intelligence-ai/jsonschema@v0.2.0
+      - run: jsonschema lint *.schema.json --verbose
+      - run: jsonschema fmt *.schema.json --check --verbose

--- a/channeldata-1.schema.json
+++ b/channeldata-1.schema.json
@@ -1,22 +1,16 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "https://schemas.conda.io/channeldata-1.schema.json",
-  "type": "object",
   "title": "channeldata.json",
   "description": "The channeldata file contains information that is common to the channel as a whole. Split out by package name, the information for each package name should be the latest available and consistent across all subdirs.",
+  "type": "object",
   "required": [
     "schema_version"
   ],
   "properties": {
     "$schema": {
-      "type": "string",
       "const": "https://schemas.conda.io/channeldata-1.schema.json",
       "format": "uri"
-    },
-    "schema_version": {
-      "type": "integer",
-      "description": "The API version or schema version of the channeldata file.",
-      "const": 1
     },
     "packages": {
       "description": "The value for each key is a package name contained within the channel.",
@@ -27,17 +21,23 @@
       },
       "additionalProperties": false
     },
+    "schema_version": {
+      "description": "The API version or schema version of the channeldata file.",
+      "const": 1
+    },
     "subdirs": {
+      "description": "All subdirs contained within the channel.",
       "type": "array",
-      "items": {"$ref": "common-1.schema.json#/definitions/subdir"},
-      "description": "All subdirs contained within the channel."
+      "items": {
+        "$ref": "common-1.schema.json#/definitions/subdir"
+      }
     }
   },
   "definitions": {
     "channeldata_record": {
       "$id": "#/definitions/channeldata_record",
-      "type": "object",
       "description": "Information about the latest version of each package name contained within the channel.",
+      "type": "object",
       "required": [
         "reference_package",
         "version"
@@ -81,29 +81,39 @@
         "license": {
           "type": "string"
         },
-        "license_family": {"$ref": "common-1.schema.json#/definitions/license_family"},
-        "spdx_license": {"$ref": "common-1.schema.json#/definitions/spdx_license"},
+        "license_family": {
+          "$ref": "common-1.schema.json#/definitions/license_family"
+        },
+        "reference_package": {
+          "description": "The {subdir}/{fn} that was used to create the entry in channeldata.",
+          "type": "string"
+        },
         "source_git_url": {
           "type": "string",
           "format": "uri"
-        },
-        "reference_package": {
-          "type": "string",
-          "description": "The {subdir}/{fn} that was used to create the entry in channeldata."
         },
         "source_url": {
           "type": "string",
           "format": "uri"
         },
+        "spdx_license": {
+          "$ref": "common-1.schema.json#/definitions/spdx_license"
+        },
         "subdirs": {
           "type": "array",
-          "items": {"$ref": "common-1.schema.json#/definitions/subdir"}
+          "items": {
+            "$ref": "common-1.schema.json#/definitions/subdir"
+          }
         },
         "summary": {
           "type": "string"
         },
-        "timestamp": {"$ref": "common-1.schema.json#/definitions/timestamp"},
-        "version": {"$ref": "common-1.schema.json#/definitions/package_version"}
+        "timestamp": {
+          "$ref": "common-1.schema.json#/definitions/timestamp"
+        },
+        "version": {
+          "$ref": "common-1.schema.json#/definitions/package_version"
+        }
       }
     }
   }

--- a/common-1.schema.json
+++ b/common-1.schema.json
@@ -2,132 +2,36 @@
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "https://schemas.conda.io/common-1.schema.json",
   "definitions": {
-    "origin_channel_name": {
-      "type": "string",
-      "description": "The origin channel of the package. Will probably be relevant for package signing.",
-      "pattern": "^([a-z0-9]+(-|_|$))+$",
-      "patchable": true,
-      "examples": [
-        "main",
-        "conda-forge"
-      ]
-    },
-    "namespace": {
-      "type": "string",
-      "title": "The ecosystem namespace for the package name.",
-      "description": "The default 'g' or 'global' namespace is for packages that aren't governed by any particular namespace authority. Most C libraries fall into the global namespace. The namespace authority for the various ecosystems is identified at https://github.com/conda/conda/blob/4.8.3/conda/base/constants.py#L259-L273.",
-      "$comment": "TODO remove global and python. Patchable is true for now, but later may become false.",
-      "patchable": true,
-      "enum": [
-        "g",
-        "py",
-        "r",
-        "erlang",
-        "java",
-        "julia",
-        "latex",
-        "lua",
-        "js",
-        "perl",
-        "php",
-        "ruby",
-        "clojure",
-        "global",
-        "python"
-      ]
-    },
-    "subdir": {
-      "type": "string",
-      "description": "The subdir of the channel within which a package is located. Subdirs are subdivisions of channels denoted by <OS>-<Platform> pairs. The 'noarch' subdir contains packages designed to be common among all subdirs.",
-      "patchable": false,
-      "enum": [
-        "noarch",
-        "linux-32",
-        "linux-64",
-        "linux-aarch64",
-        "linux-armv6l",
-        "linux-armv7l",
-        "linux-ppc64",
-        "linux-ppc64le",
-        "osx-64",
-        "win-32",
-        "win-64",
-        "zos-z"
-      ]
-    },
-    "name": {
-      "type": "string",
-      "pattern": "^[a-z0-9_](?!_)[._-]?([a-z0-9]+(\\.|-|_|$))*$",
-      "description": "The package name. Conda restricts each environment to having a single package of any unique package name.",
-      "patchable": false,
-      "examples": [
-        "python",
-        "numpy"
-      ]
-    },
-    "package_version": {
-      "type": "string",
-      "description": "The package version. Must be a valid Conda Version string (validated against VersionOrder). Versions are set by the upstream code project and should be faithfully reproduced by the package author.",
-      "pattern": "^([0-9]+!)?(([0-9a-z]+([._]))*[0-9a-z]+_?)(\\+([0-9a-z]+([._]))*[0-9a-z]+)?$",
-      "patchable": false,
-      "examples": [
-        "0.4.1",
-        "0.960923",
-        "1.1.a1",
-        "1.1.0post1",
-        "1.1.0post1+g123abcd",
-        "1996.07.12",
-        "2!0.4.1"
-      ]
-    },
-    "build_number": {
-      "type": "integer",
-      "description": "The package build number. Build numbers are incremented by package builders when a material change is made to the package. Unlike other package managers, Conda makes all package builds available during a solve, and not just the latest build number.",
-      "patchable": false,
-      "minimum": 0,
-      "examples": [
-        0,
-        1
-      ]
-    },
     "build": {
-      "type": "string",
       "description": "The package build string. The build string should include the build number in the last position of the build string. If the build string includes more than a build number, the build number should be delimited by an '_'.",
-      "patchable": false,
-      "pattern": "^([a-z0-9_.]+_)?[0-9]+$",
       "examples": [
         "0",
         "py27hbee0394_1"
-      ]
+      ],
+      "type": "string",
+      "pattern": "^([a-z0-9_.]+_)?[0-9]+$",
+      "patchable": false
+    },
+    "build_number": {
+      "description": "The package build number. Build numbers are incremented by package builders when a material change is made to the package. Unlike other package managers, Conda makes all package builds available during a solve, and not just the latest build number.",
+      "examples": [
+        0,
+        1
+      ],
+      "type": "integer",
+      "minimum": 0,
+      "patchable": false
     },
     "ext": {
-      "type": "string",
       "title": "The extension of the package file name. The .tar.bz2 extension is used by 'version 1' Conda packages and the '.conda' extension is used by 'version 2' Conda packages.",
-      "patchable": false,
       "enum": [
         ".tar.bz2",
         ".conda"
-      ]
-    },
-    "namespace_in_name": {
-      "type": "boolean",
-      "description": "Indicates if the package's namespace is in the package name. For example, the value is 'true' for the package 'python-socketio' but 'false' for the package 'python-graphviz'.",
-      "patchable": true,
-      "default": false
-    },
-    "package_id": {
-      "type": "string",
-      "description": "Except for the channel_name, the unique identifier of a package. The package_id should be generated based on other fields in the package's metadata: '{namespace}:{name}-{version}-{build_number}-{build}'",
-      "$comment": "Patchable for now, while we're still working out the details. Need to indicate subdir without having to indicate channel.",
-      "patchable": true,
-      "examples": [
-        "py:ansible-1.9.3-0-py27_0"
-      ]
+      ],
+      "patchable": false
     },
     "license_family": {
-      "type": "string",
       "description": "The license under which the package is distributed. Must conform to the license families listed at https://github.com/conda/conda-build/blob/3.19.1/conda_build/license_family.py#L8-L24.",
-      "patchable": true,
       "$comment": "TODO resolve capitalization issues.",
       "enum": [
         "AGPL",
@@ -151,36 +55,128 @@
         "Other",
         "other",
         null
-      ]
+      ],
+      "patchable": true
+    },
+    "name": {
+      "description": "The package name. Conda restricts each environment to having a single package of any unique package name.",
+      "examples": [
+        "python",
+        "numpy"
+      ],
+      "type": "string",
+      "pattern": "^[a-z0-9_](?!_)[._-]?([a-z0-9]+(\\.|-|_|$))*$",
+      "patchable": false
+    },
+    "namespace": {
+      "title": "The ecosystem namespace for the package name.",
+      "description": "The default 'g' or 'global' namespace is for packages that aren't governed by any particular namespace authority. Most C libraries fall into the global namespace. The namespace authority for the various ecosystems is identified at https://github.com/conda/conda/blob/4.8.3/conda/base/constants.py#L259-L273.",
+      "$comment": "TODO remove global and python. Patchable is true for now, but later may become false.",
+      "enum": [
+        "g",
+        "py",
+        "r",
+        "erlang",
+        "java",
+        "julia",
+        "latex",
+        "lua",
+        "js",
+        "perl",
+        "php",
+        "ruby",
+        "clojure",
+        "global",
+        "python"
+      ],
+      "patchable": true
+    },
+    "namespace_in_name": {
+      "description": "Indicates if the package's namespace is in the package name. For example, the value is 'true' for the package 'python-socketio' but 'false' for the package 'python-graphviz'.",
+      "default": false,
+      "type": "boolean",
+      "patchable": true
+    },
+    "origin_channel_name": {
+      "description": "The origin channel of the package. Will probably be relevant for package signing.",
+      "examples": [
+        "main",
+        "conda-forge"
+      ],
+      "type": "string",
+      "pattern": "^([a-z0-9]+(-|_|$))+$",
+      "patchable": true
+    },
+    "package_id": {
+      "description": "Except for the channel_name, the unique identifier of a package. The package_id should be generated based on other fields in the package's metadata: '{namespace}:{name}-{version}-{build_number}-{build}'",
+      "$comment": "Patchable for now, while we're still working out the details. Need to indicate subdir without having to indicate channel.",
+      "examples": [
+        "py:ansible-1.9.3-0-py27_0"
+      ],
+      "type": "string",
+      "patchable": true
+    },
+    "package_version": {
+      "description": "The package version. Must be a valid Conda Version string (validated against VersionOrder). Versions are set by the upstream code project and should be faithfully reproduced by the package author.",
+      "examples": [
+        "0.4.1",
+        "0.960923",
+        "1.1.a1",
+        "1.1.0post1",
+        "1.1.0post1+g123abcd",
+        "1996.07.12",
+        "2!0.4.1"
+      ],
+      "type": "string",
+      "pattern": "^([0-9]+!)?(([0-9a-z]+([._]))*[0-9a-z]+_?)(\\+([0-9a-z]+([._]))*[0-9a-z]+)?$",
+      "patchable": false
     },
     "spdx_license": {
-      "type": "string",
       "description": "The SPDX license description of the package. https://spdx.org/licenses/ The first section of the string, delimited by a colon, is the SPDX specification version. Note that this is the specification version that describes the schema for spdx_license, not the SPDX license list version (https://github.com/sindresorhus/spdx-license-list/blob/master/spdx.json).",
-      "pattern": "^[0-9]\\.[0-9]:.*$",
-      "patchable": true,
       "$comment": "Consider validation using https://github.com/nexB/license-expression. https://github.com/sindresorhus/spdx-license-list/blob/master/spdx-simple.json",
       "examples": [
         "2.1:BSD-3-Clause",
         "2.1:MIT OR Apache-2.0"
-      ]
+      ],
+      "type": "string",
+      "pattern": "^[0-9]\\.[0-9]:.*$",
+      "patchable": true
+    },
+    "subdir": {
+      "description": "The subdir of the channel within which a package is located. Subdirs are subdivisions of channels denoted by <OS>-<Platform> pairs. The 'noarch' subdir contains packages designed to be common among all subdirs.",
+      "enum": [
+        "noarch",
+        "linux-32",
+        "linux-64",
+        "linux-aarch64",
+        "linux-armv6l",
+        "linux-armv7l",
+        "linux-ppc64",
+        "linux-ppc64le",
+        "osx-64",
+        "win-32",
+        "win-64",
+        "zos-z"
+      ],
+      "patchable": false
     },
     "timestamp": {
-      "type": "integer",
-      "maximum": 253402300799,
-      "$comment": "Maximum corresponds to 9999-12-31. Helps ensure units are in seconds.",
       "description": "The Unix time (Epoch time) when the package was created. If a legacy 'date' field is provided and timestamp is not, it should be used to populate the timestamp field.",
-      "patchable": true,
+      "$comment": "Maximum corresponds to 9999-12-31. Helps ensure units are in seconds.",
       "examples": [
         1539182577753
-      ]
+      ],
+      "type": "integer",
+      "maximum": 253402300799,
+      "patchable": true
     },
     "vuln_id": {
       "description": "A CVE or other vulnerability identifier.",
-      "type": "string",
-      "pattern": "^CVE-[0-9]{4}-[0-9]{4,8}$",
       "examples": [
         "CVE-2017-14501"
-      ]
+      ],
+      "type": "string",
+      "pattern": "^CVE-[0-9]{4}-[0-9]{4,8}$"
     }
   }
 }

--- a/info-security-1.schema.json
+++ b/info-security-1.schema.json
@@ -1,85 +1,96 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "https://schemas.conda.io/info-security-1.schema.json",
-  "type": "object",
   "title": "info/security.json",
   "description": "Security-related information for the package.",
+  "type": "object",
   "required": [
     "schema_version"
   ],
   "properties": {
     "$schema": {
-      "type": "string",
       "const": "https://schemas.conda.io/info-security-1.schema.json",
       "format": "uri"
     },
     "schema_version": {
+      "description": "Schema version for the current file.",
       "type": "integer",
-      "minimum": 1,
-      "description": "Schema version for the current file."
+      "minimum": 1
+    },
+    "vulns_active": {
+      "description": "Vulnerabilities that have been identified for the package that are potentially active and exploitable.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/vuln_description_item"
+      }
+    },
+    "vulns_cleared": {
+      "description": "Vulnerabilities associated with the package that have been analyzed and determined to not be applicable.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/vuln_description_item"
+      }
+    },
+    "vulns_disputed": {
+      "description": "Vulnerabilities where one party, particularly the project maintainers, disagrees with another party's assertion that a particular issue in software is a vulnerability",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/vuln_description_item"
+      }
     },
     "vulns_mitigated": {
       "description": "Vulnerabilities that have been identified for the package but have actively been mitigated in this package build through a code patch.",
       "type": "array",
       "items": {
         "allOf": [
-          {"$ref": "#/definitions/vuln_description_item"},
+          {
+            "$ref": "#/definitions/vuln_description_item"
+          },
           {
             "properties": {
               "patch_fn": {
-                "type": "string",
-                "description": "The path for the mitigating patch within the recipe."
+                "description": "The path for the mitigating patch within the recipe.",
+                "type": "string"
               },
               "patch_src_url": {
+                "description": "The public source for the mitigating patch being applied.",
                 "type": "string",
-                "format": "uri",
-                "description": "The public source for the mitigating patch being applied."
+                "format": "uri"
               }
             }
           }
         ]
       }
-    },
-    "vulns_disputed": {
-      "description": "Vulnerabilities where one party, particularly the project maintainers, disagrees with another party's assertion that a particular issue in software is a vulnerability",
-      "type": "array",
-      "items": {"$ref": "#/definitions/vuln_description_item"}
-    },
-    "vulns_cleared": {
-      "description": "Vulnerabilities associated with the package that have been analyzed and determined to not be applicable.",
-      "type": "array",
-      "items": {"$ref": "#/definitions/vuln_description_item"}
-    },
-    "vulns_active": {
-      "description": "Vulnerabilities that have been identified for the package that are potentially active and exploitable.",
-      "type": "array",
-      "items": {"$ref": "#/definitions/vuln_description_item"}
     }
   },
   "definitions": {
     "vuln_description_item": {
       "$id": "#/definitions/vuln_description_item",
       "type": "object",
-      "required": ["id"],
+      "required": [
+        "id"
+      ],
       "properties": {
         "id": {
-          "type": "string",
           "title": "Vulnerability ID",
+          "type": "string",
           "pattern": "^CVE-[0-9]{4}-[0-9]{4,6}$"
         },
-        "poc_url": {
-          "type": "string",
-          "format": "uri",
-          "description": "Location of vulnerability proof-of-concept or exploit demonstration."
-        },
         "comment": {
+          "description": "Comment field reserved for the recipe author.",
+          "type": "string"
+        },
+        "poc_url": {
+          "description": "Location of vulnerability proof-of-concept or exploit demonstration.",
           "type": "string",
-          "description": "Comment field reserved for the recipe author."
+          "format": "uri"
         },
         "references": {
           "description": "References determined to be relevant by the recipe author.",
           "type": "array",
-          "items": {"$ref": "#/definitions/vuln_description_item_reference"}
+          "items": {
+            "$ref": "#/definitions/vuln_description_item_reference"
+          }
         }
       }
     },
@@ -92,7 +103,6 @@
       ],
       "properties": {
         "type": {
-          "type": "string",
           "description": "The type of reference. Prefer adding additional enum options rather than using 'other'.",
           "enum": [
             "nist",

--- a/repodata-1.schema.json
+++ b/repodata-1.schema.json
@@ -1,66 +1,72 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "https://schemas.conda.io/repodata-1.schema.json",
-  "type": "object",
   "title": "repodata.json",
   "$comment": "TODO add back to required: repodata_version",
+  "type": "object",
   "required": [
     "info"
   ],
   "properties": {
     "$schema": {
-      "type": "string",
       "const": "https://schemas.conda.io/repodata-1.schema.json",
       "format": "uri"
     },
-    "repodata_version": {
-      "type": "integer",
-      "title": "The API version or schema version of the repodata file.",
-      "const": 1
-    },
     "info": {
       "type": "object",
+      "required": [
+        "subdir"
+      ],
       "properties": {
         "subdir": {
           "$ref": "common-1.schema.json#/definitions/subdir"
         }
-      },
-      "required": ["subdir"]
+      }
     },
     "packages": {
-      "type": "object",
       "title": "Metadata for 'v1' .tar.bz2 Conda packages.",
       "description": "Filename key of each package should be validated against {name}-{version}-{build}{ext} metadata for the package.",
+      "type": "object",
       "patternProperties": {
-        "^.+\\.tar\\.bz2$": {"$ref": "repodata-record-1.schema.json"}
+        "^.+\\.tar\\.bz2$": {
+          "$ref": "repodata-record-1.schema.json"
+        }
       },
       "additionalProperties": false
     },
     "packages.conda": {
-      "type": "object",
       "title": "Metadata for 'v2' .conda Conda packages.",
       "description": "Filename key of each package should be validated against {name}-{version}-{build}{ext} metadata for the package.",
+      "type": "object",
       "patternProperties": {
-        "^.+\\.conda$": {"$ref": "repodata-record-1.schema.json"}
+        "^.+\\.conda$": {
+          "$ref": "repodata-record-1.schema.json"
+        }
       },
       "additionalProperties": false
     },
     "removed": {
       "type": "array",
       "items": {
-        "type": "string",
-        "pattern": "^.+(\\.tar\\.bz2)|(\\.conda)$",
         "description": "Packages that had previously been in this repodata file but have now been removed.",
         "examples": [
           "blinker-1.4-py37_0.tar.bz2",
           "blinker-1.4-py37_0.conda"
-        ]
+        ],
+        "type": "string",
+        "pattern": "^.+(\\.tar\\.bz2)|(\\.conda)$"
       }
+    },
+    "repodata_version": {
+      "title": "The API version or schema version of the repodata file.",
+      "const": 1
     },
     "signatures": {
       "type": "object",
       "patternProperties": {
-        "^.+(\\.tar\\.bz2)|(\\.conda)$": {"$ref": "#/definitions/signature"}
+        "^.+(\\.tar\\.bz2)|(\\.conda)$": {
+          "$ref": "#/definitions/signature"
+        }
       },
       "additionalProperties": false
     }
@@ -68,7 +74,16 @@
   "definitions": {
     "signature": {
       "type": "object",
+      "required": [
+        "metadata_sha256",
+        "metadata_size",
+        "sig",
+        "key"
+      ],
       "properties": {
+        "key": {
+          "type": "string"
+        },
         "metadata_sha256": {
           "type": "string"
         },
@@ -78,17 +93,8 @@
         },
         "sig": {
           "type": "string"
-        },
-        "key": {
-          "type": "string"
         }
-      },
-      "required": [
-        "metadata_sha256",
-        "metadata_size",
-        "sig",
-        "key"
-      ]
+      }
     }
   }
 }

--- a/repodata-record-1.schema.json
+++ b/repodata-record-1.schema.json
@@ -1,10 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "https://schemas.conda.io/repodata-record-1.schema.json",
-  "type": "object",
   "title": "Conda Package Metadata Record Schema",
   "description": "The schema for each package file's block of metadata in repodata.",
   "$comment": "TODO add these back to required: record_version ext fn subdir",
+  "type": "object",
   "required": [
     "subdir",
     "name",
@@ -17,67 +17,29 @@
     "md5"
   ],
   "properties": {
-    "record_version": {
-      "type": "integer",
-      "description": "The API version or schema version of the record. Conda versions through at least Conda 4.8 are able to understand record_version <= 1.",
-      "const": 1,
-      "patchable": true
+    "build": {
+      "$ref": "common-1.schema.json#/definitions/build"
     },
-    "origin_channel_name": {"$ref": "common-1.schema.json#/definitions/origin_channel_name"},
-    "subdir": {"$ref": "common-1.schema.json#/definitions/subdir"},
-    "namespace": {"$ref": "common-1.schema.json#/definitions/namespace"},
-    "name": {"$ref": "common-1.schema.json#/definitions/name"},
-    "version": {"$ref": "common-1.schema.json#/definitions/package_version"},
-    "build_number": {"$ref": "common-1.schema.json#/definitions/build_number"},
-    "build": {"$ref": "common-1.schema.json#/definitions/build"},
-    "fn": {
-      "type": "string",
-      "description": "The file name should be generated based on other fields in the package's metadata, i.e. {name}-{version}-{build}{ext}. It should be validated against those fields.",
-      "patchable": false,
-      "examples": [
-        "ansible-1.9.3-py27_0.tar.bz2",
-        "basemap-1.2.0-py27hbee0394_0.conda"
-      ]
+    "build_number": {
+      "$ref": "common-1.schema.json#/definitions/build_number"
     },
-    "sha256": {
-      "type": "string",
-      "description": "The sha256 hash of the package file.",
-      "patchable": false,
-      "pattern": "^[0-9a-f]{64}$",
-      "examples": [
-        "2efb3826d65af3f3857a35f04a0ba5c6288b9b3e4e47c9e2118fbdcc190406b9"
-      ]
-    },
-    "size": {
-      "type": "integer",
-      "description": "The size of the package file in bytes.",
-      "patchable": false,
-      "minimum": 0,
-      "examples": [
-        15874157
-      ]
-    },
-    "md5": {
-      "type": "string",
-      "description": "The md5 hash of the package file.",
-      "pattern": "^[0-9a-f]{32}$",
-      "examples": [
-        "9ceda9e08e97868b6ff7c0961a40544f"
-      ]
-    },
-    "timestamp": {"$ref": "common-1.schema.json#/definitions/timestamp"},
-    "patch_version": {
-      "type": "integer",
-      "minimum": 0,
-      "description": "Metadata record patch version. Incremented for each change of the metadata record.",
+    "constrains": {
+      "description": "The package's constraints on other packages in the environment. If the package is to be installed into an environment, the other packages in the environment must conform to these constratins. A constraint can be thought of as a 'reverse dependency'.",
+      "type": "array",
+      "items": {
+        "description": "Valid Conda MatchSpec.",
+        "examples": [
+          "proj4 <6",
+          "proj <6"
+        ],
+        "type": "string"
+      },
       "patchable": true
     },
     "depends": {
-      "type": "array",
       "description": "The package's dependencies. A list of MatchSpecs required when installing the package.",
-      "patchable": true,
+      "type": "array",
       "items": {
-        "type": "string",
         "description": "Valid Conda MatchSpec.",
         "examples": [
           "geos >=3.6.2,<3.6.3.0a0",
@@ -88,87 +50,154 @@
           "python >=2.7,<2.8.0a0",
           "six",
           "vc 9.*"
-        ]
-      }
-    },
-    "constrains": {
-      "type": "array",
-      "description": "The package's constraints on other packages in the environment. If the package is to be installed into an environment, the other packages in the environment must conform to these constratins. A constraint can be thought of as a 'reverse dependency'.",
-      "patchable": true,
-      "items": {
-        "type": "string",
-        "description": "Valid Conda MatchSpec.",
-        "examples": [
-          "proj4 <6",
-          "proj <6"
-        ]
-      }
+        ],
+        "type": "string"
+      },
+      "patchable": true
     },
     "features": {
+      "description": "The features provided by the package. Format is a space-delimited string of items.",
       "deprecated": true,
       "type": "string",
-      "description": "The features provided by the package. Format is a space-delimited string of items.",
-      "patchable": true,
-      "pattern": "^([a-z0-9-_.]+( |$))*$"
+      "pattern": "^([a-z0-9-_.]+( |$))*$",
+      "patchable": true
     },
-    "track_features": {
+    "fn": {
+      "description": "The file name should be generated based on other fields in the package's metadata, i.e. {name}-{version}-{build}{ext}. It should be validated against those fields.",
+      "examples": [
+        "ansible-1.9.3-py27_0.tar.bz2",
+        "basemap-1.2.0-py27hbee0394_0.conda"
+      ],
       "type": "string",
-      "description": "The features 'tracked' by the package. Format is a space-delimited string of items. https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#track-features",
-      "patchable": true,
-      "pattern": "^([a-z0-9-_.]+( |$))*$"
+      "patchable": false
+    },
+    "license": {
+      "title": "The package's license.",
+      "description": "A free-form text field describing the packages license.",
+      "$comment": "TODO don't allow null",
+      "examples": [
+        "MIT"
+      ],
+      "type": [
+        "string",
+        "null"
+      ],
+      "patchable": true
+    },
+    "license_family": {
+      "$ref": "common-1.schema.json#/definitions/license_family"
+    },
+    "md5": {
+      "description": "The md5 hash of the package file.",
+      "examples": [
+        "9ceda9e08e97868b6ff7c0961a40544f"
+      ],
+      "type": "string",
+      "pattern": "^[0-9a-f]{32}$"
+    },
+    "name": {
+      "$ref": "common-1.schema.json#/definitions/name"
+    },
+    "namespace": {
+      "$ref": "common-1.schema.json#/definitions/namespace"
     },
     "noarch": {
-      "deprecated": true,
-      "type": "string",
       "description": "The noarch type of a package (if applicable).",
-      "patchable": true,
+      "deprecated": true,
       "enum": [
         "generic",
         "python"
-      ]
+      ],
+      "patchable": true
     },
-    "license": {
-      "$comment": "TODO don't allow null",
-      "type": ["string", "null"],
-      "title": "The package's license.",
-      "description": "A free-form text field describing the packages license.",
-      "patchable": true,
-      "examples": [
-        "MIT"
-      ]
+    "origin_channel_name": {
+      "$ref": "common-1.schema.json#/definitions/origin_channel_name"
     },
-    "license_family": {"$ref": "common-1.schema.json#/definitions/license_family"},
-    "spdx_license": {"$ref": "common-1.schema.json#/definitions/spdx_license"},
-    "vulns_active": {
-      "type": "array",
-      "description": "Vulnerabilities that have been identified for the package that are potentially active and exploitable.",
-      "patchable": true,
-      "items": {"$ref": "common-1.schema.json#/definitions/vuln_id"}
+    "patch_version": {
+      "description": "Metadata record patch version. Incremented for each change of the metadata record.",
+      "type": "integer",
+      "minimum": 0,
+      "patchable": true
     },
-    "vulns_mitigated": {
-      "type": "array",
-      "description": "Vulnerabilities that have been identified for the package but have proactively been mitigated in this package build through a code patch.",
-      "patchable": true,
-      "items": {"$ref": "common-1.schema.json#/definitions/vuln_id"}
-    },
-    "vulns_cleared": {
-      "type": "array",
-      "description": "Vulnerabilities associated with the package that have been analyzed and determined to not be applicable.",
-      "patchable": true,
-      "items": {"$ref": "common-1.schema.json#/definitions/vuln_id"}
-    },
-    "vulns_disputed": {
-      "type": "array",
-      "description": "Vulnerabilities where legitimacy as an actual vulnerability is disputed by upstream project maintainers or other community members.",
-      "patchable": true,
-      "items": {"$ref": "common-1.schema.json#/definitions/vuln_id"}
+    "post_link_message": {
+      "type": "string",
+      "patchable": true
     },
     "post_solve_message": {
       "type": "string",
       "patchable": true
     },
-    "post_link_message": {
+    "record_version": {
+      "description": "The API version or schema version of the record. Conda versions through at least Conda 4.8 are able to understand record_version <= 1.",
+      "const": 1,
+      "patchable": true
+    },
+    "sha256": {
+      "description": "The sha256 hash of the package file.",
+      "examples": [
+        "2efb3826d65af3f3857a35f04a0ba5c6288b9b3e4e47c9e2118fbdcc190406b9"
+      ],
       "type": "string",
+      "pattern": "^[0-9a-f]{64}$",
+      "patchable": false
+    },
+    "size": {
+      "description": "The size of the package file in bytes.",
+      "examples": [
+        15874157
+      ],
+      "type": "integer",
+      "minimum": 0,
+      "patchable": false
+    },
+    "spdx_license": {
+      "$ref": "common-1.schema.json#/definitions/spdx_license"
+    },
+    "subdir": {
+      "$ref": "common-1.schema.json#/definitions/subdir"
+    },
+    "timestamp": {
+      "$ref": "common-1.schema.json#/definitions/timestamp"
+    },
+    "track_features": {
+      "description": "The features 'tracked' by the package. Format is a space-delimited string of items. https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#track-features",
+      "type": "string",
+      "pattern": "^([a-z0-9-_.]+( |$))*$",
+      "patchable": true
+    },
+    "version": {
+      "$ref": "common-1.schema.json#/definitions/package_version"
+    },
+    "vulns_active": {
+      "description": "Vulnerabilities that have been identified for the package that are potentially active and exploitable.",
+      "type": "array",
+      "items": {
+        "$ref": "common-1.schema.json#/definitions/vuln_id"
+      },
+      "patchable": true
+    },
+    "vulns_cleared": {
+      "description": "Vulnerabilities associated with the package that have been analyzed and determined to not be applicable.",
+      "type": "array",
+      "items": {
+        "$ref": "common-1.schema.json#/definitions/vuln_id"
+      },
+      "patchable": true
+    },
+    "vulns_disputed": {
+      "description": "Vulnerabilities where legitimacy as an actual vulnerability is disputed by upstream project maintainers or other community members.",
+      "type": "array",
+      "items": {
+        "$ref": "common-1.schema.json#/definitions/vuln_id"
+      },
+      "patchable": true
+    },
+    "vulns_mitigated": {
+      "description": "Vulnerabilities that have been identified for the package but have proactively been mitigated in this package build through a code patch.",
+      "type": "array",
+      "items": {
+        "$ref": "common-1.schema.json#/definitions/vuln_id"
+      },
       "patchable": true
     }
   }


### PR DESCRIPTION
Hey there! This is a PR to mainly start a conversation. I'm a member of JSON Schema organization involved in maintaining various JSON Schema related tooling (like https://alterschema.sourcemeta.com) and documentation (like https://www.learnjsonschema.com), plus co-author of the recently published O'Reilly book touching on JSON Schema (https://www.oreilly.com/library/view/unifying-business-data/9781098144999/).

Based on our experience working with organizations maintaining repositories of schemas (like you!), we've been working on an open-source CLI tool that aims to simplify development and CI/CD when dealing with schemas. This CLI supports a growing amount of commands, but I'm proposing two for this repository to start with:

- Formatting: making sure your schemas following a consistent style (i.e. indentation) plus a consistent ordering of keywords that was designed to make schemas easier to read

- Linting: we are collecting common rules to highlight anti-patterns, common pitfalls, etc when using JSON Schema. There are not that many implement out there, but the linter already caught some issues

I would love to hear your feedback, feature requests, etc to help you make better use of JSON Schema with this CLI! We also have other things on the way, like a proper JSON Schema test runner that could eventually automatically validate the examples in the repo.